### PR TITLE
Ensure detector cleaned up when AR stops

### DIFF
--- a/src/components/FindBottleView.vue
+++ b/src/components/FindBottleView.vue
@@ -44,7 +44,7 @@
 import { XMarkIcon } from "@heroicons/vue/24/outline";
 import { ref, onMounted, onUnmounted, computed, nextTick } from "vue";
 import { useVisionStore } from "../stores/vision";
-import { detectTags } from "../vision/aruco";
+import { detectTags, cleanupDetector } from "../vision/aruco";
 import { ARGuidanceService } from "../services/ar-guidance-service";
 import { db } from "../services/dexie-db";
 import type { Wine } from "../shared/Wine";
@@ -231,6 +231,7 @@ function closeView(): void {
 
 onUnmounted(() => {
   stopCamera();
+  cleanupDetector();
 });
 </script>
 

--- a/src/components/VisionCamera.vue
+++ b/src/components/VisionCamera.vue
@@ -36,7 +36,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed } from "vue";
 import { useVisionStore } from "../stores/vision";
-import { detectTags } from "../vision/aruco";
+import { detectTags, cleanupDetector } from "../vision/aruco";
 
 const props = defineProps({
   width: {
@@ -165,6 +165,7 @@ onUnmounted(() => {
     cancelAnimationFrame(animationFrameId.value);
   }
   stopCamera();
+  cleanupDetector();
 });
 </script>
 

--- a/src/services/calibration-service.ts
+++ b/src/services/calibration-service.ts
@@ -5,7 +5,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { ref } from "vue";
 import { useVisionStore } from "../stores/vision";
-import { detectTags } from "../vision/aruco";
+import { detectTags, cleanupDetector } from "../vision/aruco";
 import { loadOpenCV } from "../vision/opencv-loader";
 import type { RackDefinition, MarkerPosition } from "../shared/types/vision";
 import { db } from "./dexie-db";
@@ -75,6 +75,8 @@ export class CalibrationService {
       this.animationFrameId = null;
     }
     this.videoElement = null;
+
+    cleanupDetector();
 
     // Reset preview state
     this.preview.value = {


### PR DESCRIPTION
## Summary
- cleanup OpenCV detector on VisionCamera/FindBottleView unmount
- run cleanup in CalibrationService.stopCalibration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487e9fccf4832ebdd2d52fc7672d81